### PR TITLE
PORT-XXX: Fixing HeroSlider styles to avoid stretch images

### DIFF
--- a/web/src/components/Header/index.module.css
+++ b/web/src/components/Header/index.module.css
@@ -24,3 +24,23 @@
 	z-index: 2;
 	position: relative;
 }
+
+@media screen and (max-width: 800px) {
+  .header {
+    min-height: 30vh;
+  }
+
+	.header::before {
+		box-shadow: 0 1px 5px 0 var(--bg-primary);
+	}
+}
+
+@media screen and (max-width: 540px) {
+  .header {
+    min-height: 30vh;
+  }
+
+	.header::before {
+		box-shadow: 0 1px 5px 0 var(--bg-primary);
+	}
+}

--- a/web/src/components/Header/index.module.css
+++ b/web/src/components/Header/index.module.css
@@ -25,22 +25,14 @@
 	position: relative;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 850px) {
   .header {
     min-height: 30vh;
   }
-
-	.header::before {
-		box-shadow: 0 1px 5px 0 var(--bg-primary);
-	}
 }
 
-@media screen and (max-width: 540px) {
+@media screen and (max-width: 539px) {
   .header {
     min-height: 30vh;
   }
-
-	.header::before {
-		box-shadow: 0 1px 5px 0 var(--bg-primary);
-	}
 }

--- a/web/src/components/HeroSlider/index.module.css
+++ b/web/src/components/HeroSlider/index.module.css
@@ -30,14 +30,14 @@
   margin: 0;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 850px) {
 	.hero::before {
 		box-shadow: 0 -2rem 2rem 2rem var(--bg-primary) inset;
 	}
 }
 
-@media screen and (max-width: 540px) {
+@media screen and (max-width: 539px) {
 	.hero::before {
-		box-shadow: 0 -1rem 1rem 1rem var(--bg-primary) inset;
+		box-shadow: 0 -1.75rem 1rem 1rem var(--bg-primary) inset;
 	}
 }

--- a/web/src/components/HeroSlider/index.module.css
+++ b/web/src/components/HeroSlider/index.module.css
@@ -32,7 +32,7 @@
 
 @media screen and (max-width: 850px) {
 	.hero::before {
-		box-shadow: 0 -2rem 2rem 2rem var(--bg-primary) inset;
+		box-shadow: 0 -5rem 3rem 3rem var(--bg-primary) inset;
 	}
 }
 

--- a/web/src/components/HeroSlider/index.module.css
+++ b/web/src/components/HeroSlider/index.module.css
@@ -29,3 +29,15 @@
 .hero figure {
   margin: 0;
 }
+
+@media screen and (max-width: 800px) {
+	.hero::before {
+		box-shadow: 0 -2rem 2rem 2rem var(--bg-primary) inset;
+	}
+}
+
+@media screen and (max-width: 540px) {
+	.hero::before {
+		box-shadow: 0 -1rem 1rem 1rem var(--bg-primary) inset;
+	}
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -77,7 +77,7 @@ a:hover, a:hover:visited {
   }
 
   .carousel figcaption {
-    bottom: 1.5rem;
+    bottom: 1rem;
   }
 
   .carousel ul.control-dots {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -71,7 +71,7 @@ a:hover, a:hover:visited {
   font-size: 1rem;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 850px) {
   .carousel figure img {
     height: 50vh;
   }
@@ -85,16 +85,17 @@ a:hover, a:hover:visited {
   }
 }
 
-@media screen and (max-width: 540px) {
+@media screen and (max-width: 539px) {
   .carousel figure img {
     height: 30vh;
   }
 
   .carousel figcaption {
     bottom: 3rem;
+    display: none;
   }
 
   .carousel ul.control-dots {
-    bottom: 0;
+    bottom: -1rem;
   }
 }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -70,3 +70,31 @@ a:hover, a:hover:visited {
   bottom: 3rem;
   font-size: 1rem;
 }
+
+@media screen and (max-width: 800px) {
+  .carousel figure img {
+    height: 50vh;
+  }
+
+  .carousel figcaption {
+    bottom: 5rem;
+  }
+
+  .carousel ul.control-dots {
+    bottom: 1rem;
+  }
+}
+
+@media screen and (max-width: 540px) {
+  .carousel figure img {
+    height: 30vh;
+  }
+
+  .carousel figcaption {
+    bottom: 3rem;
+  }
+
+  .carousel ul.control-dots {
+    bottom: 0;
+  }
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -77,11 +77,11 @@ a:hover, a:hover:visited {
   }
 
   .carousel figcaption {
-    bottom: 5rem;
+    bottom: 1.5rem;
   }
 
   .carousel ul.control-dots {
-    bottom: 1rem;
+    bottom: 3rem;
   }
 }
 


### PR DESCRIPTION
## 👨🏽‍💻 Description
These changes improve the visualisation for the hero component on mobile devices. They avoid vertically stretch the images by reducing the height of them in lower resolution devices.

## ✅ Testing
Changes were testing locally using Browser Developer Tools.

## 🖼️ Evidence
Following screenshot shows how the website would look like in a Samsung Galaxy 8:
![image](https://github.com/zatarain/portfolio/assets/539783/dd30194e-7929-435f-9f9a-33c502b6bd51)

Following was taken on my phone:
![WhatsApp Image 2023-07-06 at 16 31 32](https://github.com/zatarain/portfolio/assets/539783/caddc21f-ab3c-419d-a066-3bdadb525185)
