### PR TITLE
PORT-016: Updating CV format

### DIFF
--- a/nomad/pot/flavours/portfolio-web/portfolio-web-run.sh
+++ b/nomad/pot/flavours/portfolio-web/portfolio-web-run.sh
@@ -22,4 +22,4 @@ npm run build
 echo "Web application build complete"
 
 # Run the Next.js server
-node run start
+npm run start

--- a/nomad/pot/flavours/portfolio-web/portfolio-web-run.sh
+++ b/nomad/pot/flavours/portfolio-web/portfolio-web-run.sh
@@ -22,4 +22,4 @@ npm run build
 echo "Web application build complete"
 
 # Run the Next.js server
-node src/server.ts
+node run start

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "dev": "node src/server.ts",
-    "build": "next build",
+    "build": "next build --webpack",
     "lint": "eslint .",
     "start": "node src/server.ts",
     "type-check": "tsc",

--- a/web/package.json
+++ b/web/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "dev": "node src/server.ts",
+    "dev": "next --port 5000",
     "build": "next build --webpack",
     "lint": "eslint .",
-    "start": "node src/server.ts",
+    "start": "next start -p 5000",
     "type-check": "tsc",
     "test": "COLUMNS=120 jest",
     "storybook": "storybook dev -p 5001",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "next --port 5000",
+    "dev": "next dev --port 5000",
     "build": "next build --webpack",
     "lint": "eslint .",
     "start": "next start -p 5000",

--- a/web/src/components/CurriculumVitae/__snapshots__/index.spec.tsx.snap
+++ b/web/src/components/CurriculumVitae/__snapshots__/index.spec.tsx.snap
@@ -230,6 +230,38 @@ exports[`<CurriculumVitae /> renders the component 1`] = `
       </ul>
     </section>
     <section
+      id="open-source"
+    >
+      <h2>
+        Open Source & Personal Projects
+      </h2>
+      <div
+        class="markdown contributions"
+      >
+        <p>
+          Test leadership paragraph
+        </p>
+        
+
+      </div>
+    </section>
+    <section
+      id="leadership"
+    >
+      <h2>
+        Leadership & Volunteering Activities
+      </h2>
+      <div
+        class="markdown contributions"
+      >
+        <p>
+          Test leadership paragraph
+        </p>
+        
+
+      </div>
+    </section>
+    <section
       id="awards"
     >
       <h2>
@@ -245,38 +277,6 @@ exports[`<CurriculumVitae /> renders the component 1`] = `
           Dummy Award 02
         </li>
       </ul>
-    </section>
-    <section
-      id="leadership"
-    >
-      <h2>
-        Leadership
-      </h2>
-      <div
-        class="markdown undefined"
-      >
-        <p>
-          Test leadership paragraph
-        </p>
-        
-
-      </div>
-    </section>
-    <section
-      id="volunteering"
-    >
-      <h2>
-        Volunteering Activities
-      </h2>
-      <div
-        class="markdown undefined"
-      >
-        <p>
-          Test volunteering paragraph
-        </p>
-        
-
-      </div>
     </section>
   </div>
 </DocumentFragment>

--- a/web/src/components/CurriculumVitae/index.module.css
+++ b/web/src/components/CurriculumVitae/index.module.css
@@ -47,11 +47,11 @@
 	text-align: center;
 }
 
-.experiences .contributions ul {
+.contributions ul {
 	padding-left: 1.5rem;
 }
 
-.experiences .contributions li {
+.contributions li {
 	display: list-item;
 	margin: 0;
 }
@@ -95,7 +95,7 @@
 }
 
 @media screen {
-	.ticks li::before, .experiences .contributions li::before {
+	.ticks li::before, .contributions li::before {
 		content: '';
 		display: inline-block;
 		background: url('/tick.svg') no-repeat;
@@ -118,7 +118,8 @@
 	position: relative;
 }
 
-.experiences .contributions li {
+.contributions li {
+	list-style: none;
 	position: relative;
 }
 
@@ -211,6 +212,10 @@
 	.experiences dl {
 		font-size: 0.8em;
 		width: 9.5em;
+	}
+
+	.education {
+		page-break-before: always;
 	}
 
 	.education > ul {

--- a/web/src/components/CurriculumVitae/index.tsx
+++ b/web/src/components/CurriculumVitae/index.tsx
@@ -112,19 +112,19 @@ const CurriculumVitae = ({ data }: Properties) => {
 					)}
 				</ul>
 			</section>
+			<section id="open-source">
+				<h2>Open Source &amp; Personal Projects</h2>
+				<Markdown className={styles.contributions} content={data.leadership} />
+			</section>
+			<section id="leadership">
+				<h2>Leadership &amp; Volunteering Activities</h2>
+				<Markdown className={styles.contributions} content={data.leadership} />
+			</section>
 			<section id="awards" className={styles.awards}>
 				<h2>Awards</h2>
 				<ul className={styles.ticks}>
 					{data.awards?.map((award: string, index: number) => <li key={index}>{award}</li>)}
 				</ul>
-			</section>
-			<section id="leadership">
-				<h2>Leadership</h2>
-				<Markdown content={data.leadership} />
-			</section>
-			<section id="volunteering">
-				<h2>Volunteering Activities</h2>
-				<Markdown content={data.volunteering} />
 			</section>
 		</div>
 	)

--- a/web/src/components/Header/__snapshots__/index.spec.tsx.snap
+++ b/web/src/components/Header/__snapshots__/index.spec.tsx.snap
@@ -1,9 +1,84 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`<Header /> renders the component correctly with passed name 1`] = `
+exports[`<Header /> renders the component correctly with passed name and not-defined pictures 1`] = `<DocumentFragment />`;
+
+exports[`<Header /> renders the component correctly with passed name and pictures 1`] = `
 <DocumentFragment>
   <header
     class="header"
-  />
+  >
+    <div
+      class="carousel-root hero"
+    >
+      <div
+        class="carousel carousel-slider"
+        style="width: 100%;"
+      >
+        <ul
+          class="control-dots"
+        >
+          <li
+            aria-label="slide item 1"
+            class="dot selected"
+            role="button"
+            tabindex="0"
+            value="0"
+          />
+        </ul>
+        <button
+          aria-label="previous slide / item"
+          class="control-arrow control-prev control-disabled"
+          type="button"
+        />
+        <div
+          class="slider-wrapper axis-horizontal"
+        >
+          <ul
+            class="slider animated"
+          >
+            <li
+              class="slide selected previous"
+              style="position: relative; display: block; z-index: -2; min-height: 100%; opacity: 1; top: 0px; right: 0px; left: 0px; bottom: 0px; transition-timing-function: ease-in-out; transition-duration: 1000ms;"
+            >
+              <figure>
+                <img
+                  alt="Test Caption"
+                  height="768"
+                  src="test.jpg"
+                  width="1440"
+                />
+                <figcaption>
+                  Test Caption
+                </figcaption>
+              </figure>
+            </li>
+            <li
+              class="slide selected previous"
+              style="position: relative; display: block; z-index: -2; min-height: 100%; opacity: 1; top: 0px; right: 0px; left: 0px; bottom: 0px; transition-timing-function: ease-in-out; transition-duration: 1000ms;"
+            >
+              <figure>
+                <img
+                  alt="Test Caption"
+                  height="768"
+                  src="test.jpg"
+                  width="1440"
+                />
+                <figcaption>
+                  Test Caption
+                </figcaption>
+              </figure>
+            </li>
+          </ul>
+        </div>
+        <button
+          aria-label="next slide / item"
+          class="control-arrow control-next control-disabled"
+          type="button"
+        />
+      </div>
+    </div>
+  </header>
 </DocumentFragment>
 `;
+
+exports[`<Header /> renders the component correctly with passed name, but no pictures 1`] = `<DocumentFragment />`;

--- a/web/src/components/Header/index.spec.tsx
+++ b/web/src/components/Header/index.spec.tsx
@@ -4,7 +4,33 @@ import { render } from '@testing-library/react'
 import Header from '.'
 
 describe('<Header />', () => {
-	it('renders the component correctly with passed name', () => {
+	it('renders the component correctly with passed name and pictures', () => {
+
+		const { asFragment } = render(
+			<Provider store={store}>
+				<Header data={{ name: 'My Name', pictures: [{ id: 'test', media_url: 'test.jpg', caption: 'Test Caption' }] }} />
+			</Provider>
+		)
+
+		expect(asFragment()).toMatchSnapshot()
+	})
+})
+
+describe('<Header />', () => {
+	it('renders the component correctly with passed name, but no pictures', () => {
+
+		const { asFragment } = render(
+			<Provider store={store}>
+				<Header data={{ name: 'My Name', pictures: [] }} />
+			</Provider>
+		)
+
+		expect(asFragment()).toMatchSnapshot()
+	})
+})
+
+describe('<Header />', () => {
+	it('renders the component correctly with passed name and not-defined pictures', () => {
 
 		const { asFragment } = render(
 			<Provider store={store}>

--- a/web/src/components/Header/index.tsx
+++ b/web/src/components/Header/index.tsx
@@ -7,11 +7,11 @@ interface Properties {
 }
 
 const Header = ({ data }: Properties) => {
-	return (
+	return data.pictures && data.pictures.length > 0 ? (
 		<header className={styles.header}>
 			<HeroSlider images={data.pictures || []} />
 		</header>
-	)
+	) : null
 }
 
 export default Header

--- a/web/src/components/PageLayout/__snapshots__/index.spec.tsx.snap
+++ b/web/src/components/PageLayout/__snapshots__/index.spec.tsx.snap
@@ -849,9 +849,6 @@ exports[`<PageLayout ...>...</PageLayout> renders the component correctly with p
         </li>
       </ul>
     </nav>
-    <header
-      class="header"
-    />
     <main>
       <p>
         Hello World


### PR DESCRIPTION
## 👨🏽‍💻 Description

Updating the format of the CV:
- Adding page break before education section on printable version
- Merging leadership and volunteering sections to match the new schema
- Adding open source and personal projects section
- Using tick in list items for all contributions sections

Also, hiding header hero carousel if there is no images.

Additionally, the way the application run on FreeBSD Servers has been fixed and updated.

## ✅ Testing

How did you test your changes?

* [x] ♻️ Testing visually by running the website on local sand box
* [x] 🧪 Updated impacted unit tests and correspondent snapshots